### PR TITLE
tensorflow-lite: inherit python3targetconfig

### DIFF
--- a/recipes-libraries/tensorflow-lite/tensorflow-lite_2.3.1.bb
+++ b/recipes-libraries/tensorflow-lite/tensorflow-lite_2.3.1.bb
@@ -14,7 +14,7 @@ SRC_URI += "https://storage.googleapis.com/download.tensorflow.org/models/mobile
 SRC_URI[model-mobv1.md5sum] = "36af340c00e60291931cb30ce32d4e86"
 SRC_URI[model-mobv1.sha256sum] = "d32432d28673a936b2d6281ab0600c71cf7226dfe4cdcef3012555f691744166"
 
-inherit python3native
+inherit python3native python3targetconfig
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fixes:

Missing libraries in do_compile:

cannot find crti.o: No such file or directory
cannot find crtendS.o: No such file or directory
...