### PR TITLE
armnn-swig and tensorflow-protobuf: remove COMPATIBLE_MACHINE

### DIFF
--- a/recipes-devtools/armnn-swig/armnn-swig_4.0.2.bb
+++ b/recipes-devtools/armnn-swig/armnn-swig_4.0.2.bb
@@ -5,5 +5,3 @@ SRC_URI += "file://0001-configure-use-pkg-config-for-pcre-detection.patch \
            "
 SRC_URI[md5sum] = "7c3e46cb5af2b469722cafa0d91e127b"
 SRC_URI[sha256sum] = "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-
-COMPATIBLE_MACHINE = "(mx8)"

--- a/recipes-devtools/tensorflow-protobuf/tensorflow-protobuf_3.9.2.bb
+++ b/recipes-devtools/tensorflow-protobuf/tensorflow-protobuf_3.9.2.bb
@@ -48,5 +48,3 @@ LDFLAGS:append:powerpc = " -latomic"
 LDFLAGS:append:mipsel = " -latomic"
 
 INSANE_SKIP:${PN} = "dev-so"
-
-COMPATIBLE_MACHINE = "(mx8)"


### PR DESCRIPTION
Needed or else "incompatible with machine" errors arise.
