### PR TITLE
tensorflow-lite: update SRCBRANCH to lf-5.15.5_1.0.0

### DIFF
--- a/recipes-libraries/tensorflow-lite/tensorflow-lite-2.6.0.inc
+++ b/recipes-libraries/tensorflow-lite/tensorflow-lite-2.6.0.inc
@@ -1,6 +1,5 @@
 # Copyright 2020-2021 NXP
 
 TENSORFLOW_LITE_SRC ?= "git://source.codeaurora.org/external/imx/tensorflow-imx.git;protocol=https"
-SRCBRANCH_tf = "lf-5.10.72_2.2.0"
-SRCREV_tf = "aa3013826e012f67ca94dcdb53b69c0fbc1c1999"
-
+SRCBRANCH_tf = "lf-5.15.5_1.0.0"
+SRCREV_tf = "44e6c419caeec7e6073b2fff912c20869fb03889"


### PR DESCRIPTION
As per latest NXP BSP:

https://source.codeaurora.org/external/imx/meta-imx/tree/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite-2.6.0.inc?h=honister-5.15.5-1.0.0