### PR TITLE
tensorflow-protobuf: use https protocol

### DIFF
--- a/recipes-devtools/tensorflow-protobuf/tensorflow-protobuf_3.9.2.bb
+++ b/recipes-devtools/tensorflow-protobuf/tensorflow-protobuf_3.9.2.bb
@@ -13,7 +13,7 @@ DEPENDS:append:class-target = " tensorflow-protobuf-native"
 
 SRCREV = "52b2447247f535663ac1c292e088b4b27d2910ef"
 
-SRC_URI = "git://github.com/google/protobuf.git;branch=3.9.x \
+SRC_URI = "git://github.com/google/protobuf.git;branch=3.9.x;protocol=https \
            file://run-ptest \
            file://0001-protobuf-fix-configure-error.patch \
            file://0001-Makefile.am-include-descriptor.cc-when-building-libp.patch \


### PR DESCRIPTION
Fixes the following warning:

WARNING: tensorflow-protobuf-3.9.2-r0 do_fetch: URL: git://github.com/google/protobuf.git;branch=3.9.x uses git protocol which is no longer supported
by github. Please change to ;protocol=https in the url.

Signed-off-by: Nate Drude <nate.d@variscite.com>