### PR TITLE
tensorflow-lite-vx-delegate: Allow download in do_configure task

### DIFF
--- a/recipes-libraries/tensorflow-lite/tensorflow-lite-vx-delegate_2.8.0.bb
+++ b/recipes-libraries/tensorflow-lite/tensorflow-lite-vx-delegate_2.8.0.bb
@@ -33,12 +33,12 @@ EXTRA_OECMAKE += " \
 
 CXXFLAGS += "-fPIC"
 
+do_configure[network] = "1"
 do_configure:prepend() {
     export HTTP_PROXY=${http_proxy}
     export HTTPS_PROXY=${https_proxy}
     export http_proxy=${http_proxy}
     export https_proxy=${https_proxy}
-    
 }
 
 do_install() {


### PR DESCRIPTION
Fix the following build error:

| Cloning into 'abseil-cpp'...
| fatal: unable to access 'https://github.com/abseil/abseil-cpp/': Could not resolve host: github.com

For more information, see:
https://source.codeaurora.org/external/imx/meta-imx/commit/?h=kirkstone-5.15.32-2.0.0&id=33751818b8e351572e2454eaf0ff8714d4971033

Also, remove extra line in do_configure

Signed-off-by: Nate Drude <nate.d@variscite.com>