### PR TITLE
migrate source from codeaurora to github 

### DIFF
--- a/recipes-libraries/nn-imx/nn-imx_1.3.0.bb
+++ b/recipes-libraries/nn-imx/nn-imx_1.3.0.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bba6cdb9c2b03c849ed4975ed9ed90dc"
 
 DEPENDS = "imx-gpu-viv"
-NN_IMX_SRC ?= "git://source.codeaurora.org/external/imx/nn-imx.git;protocol=https"
+NN_IMX_SRC ?= "git://github.com/nxp-imx/nn-imx.git;protocol=https"
 SRCBRANCH = "imx_1.3.0"
 
 SRCREV = "87e262fc89a7f4819b35188f9b2e7117b8563b89"

--- a/recipes-libraries/onnxruntime/onnxruntime_1.10.0.bb
+++ b/recipes-libraries/onnxruntime/onnxruntime_1.10.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "${LIC_FILES_CHKSUM_runtime} ${LIC_FILES_CHKSUM_model}"
 
 DEPENDS = "libpng zlib ${BPN}-native"
 
-ONNXRUNTIME_SRC ?= "gitsm://source.codeaurora.org/external/imx/onnxruntime-imx.git;protocol=https"
+ONNXRUNTIME_SRC ?= "gitsm://github.com/nxp-imx/onnxruntime-imx.git;protocol=https"
 SRCBRANCH_runtime = "lf-5.15.32_2.0.0"
 SRC_URI = " \
     ${ONNXRUNTIME_SRC};branch=${SRCBRANCH_runtime};name=runtime \

--- a/recipes-libraries/tvm/tvm_0.7.0.bb
+++ b/recipes-libraries/tvm/tvm_0.7.0.bb
@@ -15,7 +15,7 @@ DEPENDS = "tim-vx"
 RDEPENDS:${PN} = "tim-vx python3-decorator python3-numpy python3-attrs python3-psutil python3"
 
 SRCBRANCH = "lf-5.15.32_2.0.0"
-TVM_SRC ?= "git://source.codeaurora.org/external/imx/eiq-tvm-imx.git;protocol=ssh"
+TVM_SRC ?= "git://github.com/nxp-imx/eiq-tvm-imx.git;protocol=https"
 SRC_URI = "${TVM_SRC};branch=${SRCBRANCH}\
                git://github.com/dmlc/dlpack;protocol=https;nobranch=1;destsuffix=${S}/3rdparty/dlpack;name=dlpack \
                git://github.com/dmlc/dmlc-core;protocol=https;nobranch=1;destsuffix=${S}/3rdparty/dmlc-core;name=dmlc-core \


### PR DESCRIPTION
As of March 31, 2023, all codeaurora.org repositories have been
migrated to other platforms and the project has been shut down.
For more information, please visit: https://bye.codeaurora.org/

Signed-off-by: Nate Drude <nate.d@variscite.com>