### PR TITLE
ethos-u-vela: Fix runtime dependencies

### DIFF
--- a/recipes-libraries/ethos-u-vela/ethos-u-vela_3.6.0.bb
+++ b/recipes-libraries/ethos-u-vela/ethos-u-vela_3.6.0.bb
@@ -23,6 +23,6 @@ do_compile:prepend() {
     export https_proxy=${https_proxy}
 }
 
-RDEPENDS:${PN} += "flatbuffers python3-numpy python3-lxml"
+RDEPENDS:${PN} += "flatbuffers python3-numpy python3-lxml python3-pkg-resources"
 
 COMPATIBLE_MACHINE = "(mx93-nxp-bsp)"


### PR DESCRIPTION
vela imports pkg_resources module, so this needs to added to RDEPENDS.

See https://github.com/nxp-imx/ethos-u-vela/blob/lf-6.1.1_1.0.0/ethosu/vela/_version.py#L16 for the actual import.
Fixes the error backtrace:
```
root@tqma93xxla-mba93xxla:/usr/lib/python3.10# vela
Traceback (most recent call last):
  File "/usr/bin/vela", line 5, in <module>
    from ethosu.vela.vela import main
  File "/usr/lib/python3.10/site-packages/ethosu/vela/__init__.py", line 16, in <module>
    from ._version import __version__
  File "/usr/lib/python3.10/site-packages/ethosu/vela/_version.py", line 16, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```